### PR TITLE
Update homepage bio, restyle contact links, comment out projects/history tabs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
           <ThemeToggle onClick={toggleTheme} theme={theme} />
 
               <h1 className="text-2xl font-medium mb-6 tracking-wider text-gray-900 dark:text-gray-100">Sajda Kabir</h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400 -mt-4 mb-6">she/her</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 -mt-4 mb-6">she/her, <Link href="https://zerotrail.ai" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors">zerotrail cto</Link></p>
 
               <div className="space-y-4 text-[14px] leading-relaxed text-gray-800 dark:text-gray-200">
                 <p className="max-w-xl">I grew up in <Link href="https://en.wikipedia.org/wiki/Palashi" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">Plassey</Link> and studied Computer Science in Calcutta.</p>
@@ -39,7 +39,7 @@ export default function Home() {
 
                 <p className="max-w-xl">I prefer clean code over clever one-liners, and I can spend hours automating 10 minutes of manual work.</p>
 
-                <p className="max-w-xl">When I'm not coding, you can find me reading books, biking, playing badminton, trying new food, or cooking it in the kitchen (yeah, I can cook both code and food).</p>
+                <p className="max-w-xl">When I'm not coding, you can find me breaking code, reading, playing badminton, trying new food, or cooking it in the kitchen (yeah, I can cook both code and food).</p>
 
                 {/* <p className="max-w-xl">To know more about me, take a look at my <Link href="/history" className="underline hover:no-underline">history</Link>.</p> */}
 
@@ -55,7 +55,7 @@ export default function Home() {
                 <div className="pt-1">
                   <a
                     href="mailto:sajda.kbir@gmail.com"
-                    className="text-[14px] text-gray-600 dark:text-gray-300 hover:underline"
+                    className="text-[14px] text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
                   >
                     sajda [dot] kbir [at] gmail [dot] com
                   </a>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ export default function Footer({ showBorder = false }: FooterProps) {
       <div className="pt-1">
         <a
           href="mailto:sajda.kbir@gmail.com"
-          className="text-[14px] text-gray-600 dark:text-gray-300 hover:underline"
+          className="text-[14px] text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
         >
           sajda [dot] kbir [at] gmail [dot] com
         </a>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,9 +18,9 @@ interface NavigationProps {
 
 const navigationItems: NavigationItem[] = [
   { label: 'home', href: '/' },
-  { label: 'history', href: '/history' },
+  // { label: 'history', href: '/history' },
   { label: 'oss/acc', href: '/oss-acc' },
-  { label: 'projects', href: '/projects' },
+  // { label: 'projects', href: '/projects' },
   { label: 'writing', href: '/posts' },
   { label: 'love', href: '/photos' },
 ];

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,15 +26,15 @@ const navigationItems: NavigationItem[] = [
       </svg>
     )
   },
-  { 
-    label: 'Projects', 
-    href: '/projects', 
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-      </svg>
-    )
-  },
+  // {
+  //   label: 'Projects',
+  //   href: '/projects',
+  //   icon: (
+  //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+  //     </svg>
+  //   )
+  // },
   { 
     label: 'Notes', 
     href: '/notes', 
@@ -53,15 +53,15 @@ const navigationItems: NavigationItem[] = [
       </svg>
     )
   },
-  { 
-    label: 'History', 
-    href: '/history', 
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-      </svg>
-    )
-  }
+  // {
+  //   label: 'History',
+  //   href: '/history',
+  //   icon: (
+  //     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  //       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+  //     </svg>
+  //   )
+  // }
 ];
 
 export default function Sidebar({ theme }: SidebarProps) {


### PR DESCRIPTION
Comments out the Projects and History tabs from both the icon Sidebar and the text Navigation (routes left intact). Updates the homepage bio copy and adds a "zerotrail cto" link to zerotrail.ai next to the she/her pronouns. Restyles the email links on the homepage and in the Footer to use a grey hover effect instead of an underline, matching the rest of the contact links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)